### PR TITLE
Bugfix/#29 background scroll firstelemetsticky

### DIFF
--- a/themes/custom/shopspot/dist/css/main.css
+++ b/themes/custom/shopspot/dist/css/main.css
@@ -61,6 +61,9 @@ body a {
   padding-left: 23px;
   padding-right: 20px;
   justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: 2;
 }
 .menu--mobilenavmenu .menu-level-0 .menu-item--expanded .menu-level-1 .menu-item:first-child a span {
   width: 75%;

--- a/themes/custom/shopspot/dist/css/main.css
+++ b/themes/custom/shopspot/dist/css/main.css
@@ -61,9 +61,6 @@ body a {
   padding-left: 23px;
   padding-right: 20px;
   justify-content: space-between;
-  position: sticky;
-  top: 0;
-  z-index: 2;
 }
 .menu--mobilenavmenu .menu-level-0 .menu-item--expanded .menu-level-1 .menu-item:first-child a span {
   width: 75%;

--- a/themes/custom/shopspot/src/sass/component/_headerMobileNavMenu.scss
+++ b/themes/custom/shopspot/src/sass/component/_headerMobileNavMenu.scss
@@ -24,9 +24,6 @@
           padding-left: 23px;
           padding-right: 20px;
           justify-content: space-between;
-          position: sticky;
-          top: 0;
-          z-index: 2;
           a {
             span {
               width: 75%;

--- a/themes/custom/shopspot/src/sass/component/_headerMobileNavMenu.scss
+++ b/themes/custom/shopspot/src/sass/component/_headerMobileNavMenu.scss
@@ -24,6 +24,9 @@
           padding-left: 23px;
           padding-right: 20px;
           justify-content: space-between;
+          position: sticky;
+          top: 0;
+          z-index: 2;
           a {
             span {
               width: 75%;


### PR DESCRIPTION
The first element now sticks to the first position and others can scroll easily. 