### PR TITLE
Mega menus last menu goes out of window

### DIFF
--- a/themes/custom/shopspot/dist/css/main.css
+++ b/themes/custom/shopspot/dist/css/main.css
@@ -717,6 +717,9 @@ body a {
   display: flex;
   top: 165px;
 }
+.mega-menu .menu--mega-menu .menu-item--expanded:last-child:hover .menu-level-1 {
+  right: 60px;
+}
 .mega-menu .menu--mega-menu-for-mobile {
   display: none;
 }

--- a/themes/custom/shopspot/src/sass/component/_megaMenu.scss
+++ b/themes/custom/shopspot/src/sass/component/_megaMenu.scss
@@ -118,7 +118,7 @@
   .mega-menu {
     height: auto;
     overflow-x: hidden;
-    box-shadow: none;
+    box-shadow: none; 
     .region-menu {
       .menu--mega-menu {
         display: none;

--- a/themes/custom/shopspot/src/sass/component/_megaMenu.scss
+++ b/themes/custom/shopspot/src/sass/component/_megaMenu.scss
@@ -104,6 +104,10 @@
       display: flex;
       top: 165px;
     }
+    .menu-item--expanded:last-child:hover .menu-level-1{
+      right: 60px;
+      
+    }
   }
   .menu--mega-menu-for-mobile {
     display: none;


### PR DESCRIPTION
Child menu shifted from right to left.
![image](https://user-images.githubusercontent.com/32816725/157471834-faff8c4d-3027-4e75-9e76-9ce21a8e8095.png)
